### PR TITLE
chore: move to only building on a tag push on master

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,11 +5,10 @@ on:
     branches: 
       - master
       - main
-    tags: 
-      - '*'
 
 jobs:
   goreleaser:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
Change to only run goreleaser on a tag push